### PR TITLE
Remove baseUrl from base tsconfig

### DIFF
--- a/packages/tsconfig-config/_base.json
+++ b/packages/tsconfig-config/_base.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "baseUrl": "src",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,


### PR DESCRIPTION
some tsconfig compilerOptions don't work correctly when extended

I'll add baseUrl to the starter CLI common configuration