### PR TITLE
feat(eslint): adds sort imports

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -7,7 +7,14 @@ module.exports = {
     "prettier/@typescript-eslint",
     "plugin:prettier/recommended"
   ],
-  plugins: ["react", "@typescript-eslint", "prettier", "react-hooks"],
+  plugins: [
+    "react",
+    "@typescript-eslint",
+    "prettier",
+    "react-hooks",
+    "simple-import-sort",
+    "sort-exports"
+  ],
   env: {
     browser: true,
     node: true,
@@ -27,6 +34,18 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": [
       "error",
       { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }
+    ],
+    "sort-exports/sort-exports": ["error", { sortDir: "asc" }],
+    "simple-import-sort/sort": [
+      "error",
+      {
+        groups: [
+          ["^\\u0000"],
+          ["^@?\\w"],
+          ["^[^.|components]"],
+          ["^\\.|components"]
+        ]
+      }
     ]
   },
   overrides: [

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -15,6 +15,8 @@
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.17.0",
     "eslint-plugin-react-hooks": "^2.3.0",
+    "eslint-plugin-simple-import-sort": "^5.0.0",
+    "eslint-plugin-sort-exports": "^0.2.0",
     "typescript": "^3.7.3"
   }
 }


### PR DESCRIPTION
Before:

```jsx
import React from 'react';

import { Button } from 'components/UI';

import { graphql, Link } from 'gatsby';
```

After:
```jsx
import { graphql, Link } from 'gatsby';
import React from 'react';

import { Button } from 'components/UI';

```

---

Closes #4 