### PR TITLE
feat: use eslint-plugin-import

### DIFF
--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -26,6 +26,19 @@ On `.eslintrc.json` file add:
 }
 ```
 
+## Import order with absolute paths
+
+If you have absolute paths, you probably don't want something like `components/Button` to be considered external:
+
+```json
+{
+  "extends": "@significa/eslint-config",
+  "settings": {
+    "import/internal-regex": "^components/|^utils/"
+  }
+}
+```
+
 ## License
 
 [MIT](https://github.com/Significa/significa-style/blob/master/LICENSE)

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -5,7 +5,7 @@ module.exports = {
     "plugin:react/recommended",
     "plugin:prettier/recommended"
   ],
-  plugins: ["react", "prettier", "react-hooks", "simple-import-sort"],
+  plugins: ["react", "prettier", "react-hooks", "import"],
   env: {
     browser: true,
     node: true,
@@ -20,12 +20,15 @@ module.exports = {
   rules: {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "simple-import-sort/sort": [
-      "error",
-      {
-        groups: [["^\\u0000"], ["^@?\\w"], ["^[a-z]{0,}\\/|^[^.]"], ["^\\."]]
-      }
-    ]
+    {
+      "groups": [
+        "builtin",
+        "external",
+        "internal",
+        ["parent", "sibling", "index"]
+      ],
+      "newlines-between": "always"
+    }
   },
   overrides: [
     {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -13,10 +13,10 @@
     "babel-eslint": "^10.0.3",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.18.0",
     "eslint-plugin-react-hooks": "^2.3.0",
-    "eslint-plugin-simple-import-sort": "^5.0.1",
     "typescript": "^3.7.5"
   }
 }


### PR DESCRIPTION
This PR removes `simple-import-sort` and adds `import` with reasonable configuration:
- no alphabetical ordering
- mandatory line break between groups
- group sibling and parent files together

It also adds to the README some quick guide on how to tell ESLint what are internal paths to help with absolute path projects