### PR TITLE
fix(eslint): import config

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -20,15 +20,18 @@ module.exports = {
   rules: {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    {
-      "groups": [
-        "builtin",
-        "external",
-        "internal",
-        ["parent", "sibling", "index"]
-      ],
-      "newlines-between": "always"
-    }
+    "import/order": [
+      "error",
+      {
+        groups: [
+          "builtin",
+          "external",
+          "internal",
+          ["parent", "sibling", "index"]
+        ],
+        "newlines-between": "always"
+      }
+    ]
   },
   overrides: [
     {


### PR DESCRIPTION
The `import` config was missing the proper key declaration.