### PR TITLE
fix: add import errors and warnings

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -5,6 +5,9 @@ module.exports = {
     "plugin:react/recommended",
     "plugin:prettier/recommended",
     "plugin:jsx-a11y/recommended",
+    "plugin:import/errors",
+    "plugin:import/warnings",
+    "plugin:import/typescript",
   ],
   plugins: ["react", "prettier", "react-hooks", "import", "jest"],
   parserOptions: {
@@ -21,6 +24,11 @@ module.exports = {
     react: {
       pragma: "React",
       version: "detect",
+    },
+    "import/resolver": {
+      node: {
+        moduleDirectory: ["node_modules", "src/"],
+      },
     },
   },
   rules: {
@@ -67,4 +75,4 @@ module.exports = {
       },
     },
   ],
-};
+}


### PR DESCRIPTION
## Description

Allow eslint to display errors about wrong imports.
